### PR TITLE
fix: complex pointer types are detected corrrectly

### DIFF
--- a/pkg/analyzer/analyzer.go
+++ b/pkg/analyzer/analyzer.go
@@ -85,7 +85,12 @@ func (c *conseal) checkCompositeLit(lit *ast.CompositeLit, pass *analysis.Pass) 
 		return
 	}
 
-	named, ok := tv.Type.(*types.Named)
+	typ := tv.Type
+	if ptr, ok := typ.(*types.Pointer); ok {
+		typ = ptr.Elem()
+	}
+
+	named, ok := typ.(*types.Named)
 	if !ok {
 		return
 	}

--- a/pkg/analyzer/testdata/basic/app/main.go
+++ b/pkg/analyzer/testdata/basic/app/main.go
@@ -30,3 +30,103 @@ func DirectAssignment() {
 
 	user.Name = "Dave" // want "direct assignment to field Name of struct User is prohibited, use constructor function"
 }
+
+func InSlice() {
+	users := []domain.User{
+		{ // want "direct construction of struct User is prohibited, use constructor function"
+			ID:   1,
+			Name: "Alice",
+			Age:  30,
+		},
+		{ // want "direct construction of struct User is prohibited, use constructor function"
+			ID:   2,
+			Name: "Bob",
+			Age:  25,
+		},
+	}
+	_ = users
+}
+
+func InSlicePointer() {
+	users := []*domain.User{
+		{ // want "direct construction of struct User is prohibited, use constructor function"
+			ID:   1,
+			Name: "Alice",
+			Age:  30,
+		},
+		{ // want "direct construction of struct User is prohibited, use constructor function"
+			ID:   2,
+			Name: "Bob",
+			Age:  25,
+		},
+	}
+	_ = users
+}
+
+func InMap() {
+	userMap := map[int]domain.User{
+		1: { // want "direct construction of struct User is prohibited, use constructor function"
+			ID:   1,
+			Name: "Alice",
+			Age:  30,
+		},
+		2: { // want "direct construction of struct User is prohibited, use constructor function"
+			ID:   2,
+			Name: "Bob",
+			Age:  25,
+		},
+	}
+	_ = userMap
+}
+
+func InMapPointer() {
+	userMap := map[int]*domain.User{
+		1: { // want "direct construction of struct User is prohibited, use constructor function"
+			ID:   1,
+			Name: "Alice",
+			Age:  30,
+		},
+		2: { // want "direct construction of struct User is prohibited, use constructor function"
+			ID:   2,
+			Name: "Bob",
+			Age:  25,
+		},
+	}
+	_ = userMap
+}
+
+func InArray() {
+	users := [2]domain.User{
+		{ // want "direct construction of struct User is prohibited, use constructor function"
+			ID:   1,
+			Name: "Alice",
+			Age:  30,
+		},
+		{ // want "direct construction of struct User is prohibited, use constructor function"
+			ID:   2,
+			Name: "Bob",
+			Age:  25,
+		},
+	}
+	_ = users
+}
+
+func InNestedSlice() {
+	nestedUsers := [][]domain.User{
+		{
+			domain.User{ // want "direct construction of struct User is prohibited, use constructor function"
+				ID:   1,
+				Name: "Alice",
+				Age:  30,
+			},
+		},
+		{
+			{ // want "direct construction of struct User is prohibited, use constructor function"
+				ID:   2,
+				Name: "Bob",
+				Age:  25,
+			},
+		},
+	}
+	_ = nestedUsers
+}


### PR DESCRIPTION
## Summary

fix direct construction of complex types(array, slice, and map) with struct detection

close #1

## Changes

- fix pointer-type handling
- update testcases with array, slice and map