### PR TITLE
chore: use github pr for releases

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -33,6 +33,7 @@ archives:
         format: zip
 
 changelog:
+  use: github
   sort: asc
   filters:
     exclude:


### PR DESCRIPTION
use GitHub PR for changelog generation, instead of git log